### PR TITLE
Server: change the server to receive multiple connections sequentially

### DIFF
--- a/include/Server.h
+++ b/include/Server.h
@@ -20,6 +20,8 @@ public:
   void stop();
 
 private:
+  void close_socket(int &socket_fd);
+
   int port_;
   int main_socket_fd_ = -1;
   std::unique_ptr<IClientHandler> client_handler_;

--- a/main.cpp
+++ b/main.cpp
@@ -3,11 +3,11 @@
 
 int main() {
   Server game_server(HandlerType::ECHO);
-  if (game_server.start()) {
-    std::cout << "서버 로직이 (단일 클라이언트 처리 후) 완료되었습니다."
-              << std::endl;
+  if (!game_server.start()) {
+    std::cerr << "Server: Server start failed." << std::endl;
   }
-  game_server.stop();
+
+  std::cout << "서버 프로그램의 main 함수가 종료됩니다." << std::endl;
 
   return 0;
 }

--- a/src/EchoClientHandler.cpp
+++ b/src/EchoClientHandler.cpp
@@ -1,5 +1,6 @@
 #include "../include/EchoClientHandler.h"
-#include <cstring>      // For strlen
+#include <cerrno>       // For errno
+#include <cstring>      // For strlen, strerror
 #include <iostream>     // For std::cout, perror
 #include <sys/socket.h> // For send()
 #include <unistd.h>     // For close(), read(), send()
@@ -11,13 +12,21 @@ void EchoClientHandler::handle_client(int client_socket) {
   ssize_t bytes_read = read(client_socket, buffer, BUFFER_SIZE_ECHOHANDLER);
 
   if (bytes_read < 0) {
-    perror("EchoClientHandler: read failed");
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      std::cerr << "EchoClientHandler: Read timeout for socket "
+                << client_socket << std::endl;
+    } else {
+      std::cerr << "EchoClientHandler: read failed on socket " << client_socket
+                << " with errno " << errno << ": " << strerror(errno)
+                << std::endl;
+    }
     close(client_socket);
     return;
   }
   if (bytes_read == 0) {
-    std::cout << "EchoClientHandler: Client connection closed by peer."
-              << std::endl;
+    std::cout
+        << "EchoClientHandler: Client connection closed by peer on socket "
+        << client_socket << "." << std::endl;
     close(client_socket);
     return;
   }
@@ -26,12 +35,13 @@ void EchoClientHandler::handle_client(int client_socket) {
     buffer[bytes_read] = '\0';
   } else {
     buffer[BUFFER_SIZE_ECHOHANDLER - 1] = '\0';
-    std::cout
-        << "EchoClientHandler: Buffer received is larger than buffer size."
-        << std::endl;
+    std::cout << "EchoClientHandler: Buffer received is larger than buffer "
+                 "size on socket "
+              << client_socket << "." << std::endl;
   }
 
-  std::cout << "EchoClientHandler: Received message: " << buffer << std::endl;
+  std::cout << "EchoClientHandler: Received message from socket "
+            << client_socket << ": " << buffer << std::endl;
 
   // 한 번에 send가 일부만 전송할 수 있으므로, 반복문으로 처리 통해 안정성 확보
   ssize_t bytes_sent = 0;
@@ -39,17 +49,28 @@ void EchoClientHandler::handle_client(int client_socket) {
     ssize_t bytes_sent_this_time =
         send(client_socket, buffer + bytes_sent, bytes_read - bytes_sent, 0);
     if (bytes_sent_this_time < 0) {
-      perror("EchoClientHandler: send failed");
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        std::cerr << "EchoClientHandler: Send timeout for socket "
+                  << client_socket << std::endl;
+      } else {
+        std::cerr << "EchoClientHandler: send failed on socket "
+                  << client_socket << " with errno " << errno << ": "
+                  << strerror(errno) << std::endl;
+      }
       break;
     }
     bytes_sent += bytes_sent_this_time;
   }
+
   if (bytes_sent < bytes_read) {
-    std::cout << "EchoClientHandler: Partial message sent." << std::endl;
+    std::cout << "EchoClientHandler: Partial message sent to socket "
+              << client_socket << "." << std::endl;
   } else {
-    std::cout << "EchoClientHandler: Echo message sent." << std::endl;
+    std::cout << "EchoClientHandler: Echo message sent to socket "
+              << client_socket << "." << std::endl;
   }
 
   close(client_socket);
-  std::cout << "EchoClientHandler: Client connection closed." << std::endl;
+  std::cout << "EchoClientHandler: Client connection closed for socket "
+            << client_socket << "." << std::endl;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -47,7 +47,7 @@ bool Server::start() {
   if (setsockopt(main_socket_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) <
       0) {
     perror("Server: setsockopt failed");
-    stop();
+    close_socket(main_socket_fd_);
     return false;
   }
 
@@ -61,49 +61,53 @@ bool Server::start() {
 
   if (bind(main_socket_fd_, (struct sockaddr *)&address, sizeof(address)) < 0) {
     perror("Server: bind failed");
-    stop();
+    close_socket(main_socket_fd_);
     return false;
   }
 
   if (listen(main_socket_fd_, 3) < 0) {
     perror("Server: listen failed");
-    stop();
+    close_socket(main_socket_fd_);
     return false;
   }
 
   std::cout << "서버가 포트 " << port_ << "에서 대기 중입니다..." << std::endl;
 
-  int client_socket;
-  socklen_t addrlen = sizeof(address);
-  if ((client_socket = accept(main_socket_fd_, (struct sockaddr *)&address,
-                              &addrlen)) < 0) {
-    perror("Server: accept failed");
-    stop();
-    return false;
+  while (true) {
+    int client_socket;
+    socklen_t addrlen = sizeof(address);
+    if ((client_socket = accept(main_socket_fd_, (struct sockaddr *)&address,
+                                &addrlen)) < 0) {
+      perror("Server: accept failed");
+      continue;
+    }
+
+    std::cout << "클라이언트가 연결되었습니다." << std::endl;
+
+    const char *connect_success_msg = "Server: Connection successful!\n";
+    if (send(client_socket, connect_success_msg, strlen(connect_success_msg),
+             0) < 0) {
+      perror("Server: failed to send connection success message");
+      continue;
+    }
+
+    client_handler_->handle_client(client_socket);
+    std::cout << "클라이언트 처리 완료, 다음 연결 대기 중..." << std::endl;
   }
-
-  std::cout << "클라이언트가 연결되었습니다." << std::endl;
-
-  const char *connect_success_msg = "Server: Connection successful!\n";
-  if (send(client_socket, connect_success_msg, strlen(connect_success_msg), 0) <
-      0) {
-    perror("Server: failed to send connection success message");
-    stop();
-    return false;
-  }
-
-  // 여기서는 단일 클라이언트 처리를 위해 바로 객체를 생성하고 호출합니다.
-  // 다중 클라이언트 처리를 위해서는 이 부분을 스레드 생성 로직으로 변경해야
-  // 합니다. 클라이언트 소켓은 기본 에코 서버에서는 핸들러 내에서 닫힙니다.
-  client_handler_->handle_client(client_socket);
 
   return true;
 }
 
 void Server::stop() {
   if (main_socket_fd_ != -1) {
-    close(main_socket_fd_);
-    main_socket_fd_ = -1;
+    close_socket(main_socket_fd_);
     std::cout << "Server: Listener socket closed. Server stopped." << std::endl;
+  }
+}
+
+void Server::close_socket(int &socket_fd) {
+  if (socket_fd != -1) {
+    close(socket_fd);
+    socket_fd = -1;
   }
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -79,6 +79,7 @@ bool Server::start() {
     if ((client_socket = accept(main_socket_fd_, (struct sockaddr *)&address,
                                 &addrlen)) < 0) {
       perror("Server: accept failed");
+      close_socket(client_socket);
       continue;
     }
 
@@ -88,11 +89,13 @@ bool Server::start() {
     if (send(client_socket, connect_success_msg, strlen(connect_success_msg),
              0) < 0) {
       perror("Server: failed to send connection success message");
+      close_socket(client_socket);
       continue;
     }
 
     client_handler_->handle_client(client_socket);
     std::cout << "클라이언트 처리 완료, 다음 연결 대기 중..." << std::endl;
+    close_socket(client_socket);
   }
 
   return true;


### PR DESCRIPTION
- server class is changed to receive multiple connections sequentially
- server doesn't close the socket after handling a client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 서버가 여러 클라이언트의 연결을 연속적으로 받아 처리할 수 있도록 변경되었습니다.

- **버그 수정**
    - 서버 소켓 종료 및 에러 처리 로직이 개선되어, 오류 발생 시 소켓이 안전하게 닫히고 자원이 해제됩니다.
    - 클라이언트 소켓의 송수신 타임아웃 설정이 추가되어 연결 안정성이 향상되었습니다.
    - 클라이언트 처리 중 발생하는 타임아웃 및 에러에 대한 상세한 로그가 추가되었습니다.

- **리팩토링**
    - 소켓 종료 동작이 별도의 메서드로 분리되어 코드의 안정성과 유지보수성이 향상되었습니다.

- **기타**
    - 서버 시작 실패 시 명확한 오류 메시지가 출력됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->